### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/brimoaplikasi5/74d56477-84d7-428a-915e-6f4390c90f36/a4df8295-55b9-4bcd-8a6d-d45cfb55c832/_apis/work/boardbadge/234cb483-15ff-44a0-928d-65d2d1de4bd5)](https://dev.azure.com/brimoaplikasi5/74d56477-84d7-428a-915e-6f4390c90f36/_boards/board/t/a4df8295-55b9-4bcd-8a6d-d45cfb55c832/Microsoft.RequirementCategory)
 # update


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/brimoaplikasi5/74d56477-84d7-428a-915e-6f4390c90f36/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.